### PR TITLE
[Feature] Add a wizard for two level inverter filters calculation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,12 @@ if(INCLUDE_MKF_TESTS)
     target_link_libraries(MKF_tests UnitTest++)
 endif(INCLUDE_MKF_TESTS)
 
+option(DEBUG_PLOTS "Enable detailed debug plots" OFF)
+
+if(DEBUG_PLOTS)
+    add_definitions(-DDEBUG_PLOTS)
+endif()
+
 if(INCLUDE_PYMKF)
         FetchContent_Declare(pybind11
                 GIT_REPOSITORY https://github.com/pybind/pybind11.git)

--- a/src/converter_models/DebugPlots.hpp
+++ b/src/converter_models/DebugPlots.hpp
@@ -1,0 +1,300 @@
+#pragma once
+
+#ifdef DEBUG_PLOTS
+#include <matplot/matplot.h>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <complex>
+
+namespace debug_plots {
+    using namespace matplot;
+
+    static std::string base_folder = "debug_plots";
+
+    inline void init_folder() {
+        std::filesystem::create_directories(base_folder);
+    }
+
+    inline std::string path(const std::string& filename) {
+        return base_folder + "/" + filename;
+    }
+
+    inline void plot_fft_db(const std::vector<double>& freq,
+                        const std::vector<double>& spectrum,
+                        const std::string& label,
+                        const std::string& filename) {
+    // Compute magnitude in dB
+    std::vector<double> spectrum_dB(spectrum.size());
+    std::transform(spectrum.begin(), spectrum.end(), spectrum_dB.begin(),
+                   [](double v) {
+                       double mag = std::abs(v);
+                       return (mag > 1e-12) ? 20.0 * std::log10(mag) : -120.0; // floor
+                   });
+
+    figure(true);
+    semilogx(freq, spectrum_dB)->display_name(label); // log-x axis
+    xlabel("Frequency [Hz]");
+    ylabel("Amplitude [dB]");
+    title("FFT Spectrum (" + label + ")");
+    grid(true);
+    save(path(filename));
+    }
+
+    // === 1. Carrier Plot (only a few switching periods) ===
+    inline void plot_carrier(const std::vector<double>& carrier,
+                             double fsw) {
+        auto t = linspace(0, 5.0 / fsw, carrier.size());
+        figure(true);
+        plot(t, carrier)->display_name("Carrier");
+        xlabel("Time [s]");
+        ylabel("Amplitude");
+        title("Carrier over 5 switching periods");
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("carrier.png"));
+    }
+
+    // === 2. Carrier vs Reference (1 fundamental period) ===
+    inline void plot_carrier_vs_ref(const std::vector<double>& carrier,
+                                    const std::vector<double>& reference,
+                                    double f1) {
+        auto t = linspace(0, 1.0 / f1, carrier.size());
+        figure(true);
+        hold(true);
+        plot(t, carrier)->display_name("Carrier");
+        plot(t, reference)->display_name("Reference");
+        legend();
+        xlabel("Time [s]");
+        ylabel("Amplitude");
+        title("Carrier vs Reference");
+        hold(false);
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("carrier_vs_ref.png"));
+    }
+
+        // === 2. Carrier vs References (1 fundamental period, all 3 phases) ===
+    inline void plot_carrier_vs_refs(const std::vector<double>& carrier,
+                                     const std::vector<double>& refA,
+                                     const std::vector<double>& refB,
+                                     const std::vector<double>& refC,
+                                     double f1) {
+        // Make sure all vectors are same length
+        size_t N = std::min({carrier.size(), refA.size(), refB.size(), refC.size()});
+        auto t = linspace(0, 1.0 / f1, N);
+
+        figure(true);
+        hold(true);
+
+        plot(t, carrier)->display_name("Carrier");
+        plot(t, refA)->display_name("Reference A");
+        plot(t, refB)->display_name("Reference B");
+        plot(t, refC)->display_name("Reference C");
+
+        legend();
+        xlabel("Time [s]");
+        ylabel("Normalized amplitude");
+        title("Carrier vs References (1 fundamental period)");
+        grid(true);
+
+        hold(false);
+        gcf()->size(1920, 1080);   // 4K output
+        save(path("carrier_vs_refs.png"));
+    }
+
+    // === 3. Comparator (PWM) outputs ===
+    inline void plot_pwm_signals(const std::vector<int>& gateA,
+                                const std::vector<int>& gateB,
+                                const std::vector<int>& gateC,
+                                double f1, double fs) {
+        const double Tfund = 1.0 / f1;
+        size_t Nfund = static_cast<size_t>(std::round(Tfund * fs));
+        Nfund = std::min({Nfund, gateA.size(), gateB.size(), gateC.size()});
+
+        std::vector<int> A(gateA.begin(), gateA.begin() + Nfund);
+        std::vector<int> B(gateB.begin(), gateB.begin() + Nfund);
+        std::vector<int> C(gateC.begin(), gateC.begin() + Nfund);
+
+        auto t = linspace(0, Tfund, Nfund);
+        figure(true);
+        hold(true);
+        stairs(t, A)->display_name("Gate A");
+        stairs(t, B)->display_name("Gate B");
+        stairs(t, C)->display_name("Gate C");
+        legend();
+        xlabel("Time [s]");
+        ylabel("Gate signal (0/1)");
+        title("PWM Comparator Outputs (1 fundamental period)");
+        grid(true);
+        hold(false);
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("pwm_signals.png"));
+    }
+
+    // === 3. Output comparison (va,vb,vc over 2 fsw) ===
+    inline void plot_va_vb_vc_short(const std::vector<double>& va,
+                                    const std::vector<double>& vb,
+                                    const std::vector<double>& vc,
+                                    double fsw,
+                                    double fs) {
+        const double Tshort = 2.0 / fsw;
+        size_t Nshort = static_cast<size_t>(std::round(Tshort * fs));
+        Nshort = std::min({Nshort, va.size(), vb.size(), vc.size()});
+
+        std::vector<double> va_short(va.begin(), va.begin() + Nshort);
+        std::vector<double> vb_short(vb.begin(), vb.begin() + Nshort);
+        std::vector<double> vc_short(vc.begin(), vc.begin() + Nshort);
+
+        auto t = linspace(0, Tshort, Nshort);
+        figure(true);
+        hold(true);
+        plot(t, va_short)->display_name("va");
+        plot(t, vb_short)->display_name("vb");
+        plot(t, vc_short)->display_name("vc");
+        legend();
+        xlabel("Time [s]");
+        ylabel("Voltage [V]");
+        title("va, vb, vc (2 switching periods)");
+        hold(false);
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("va_vb_vc_short.png"));
+    }
+
+    // === 4. Output comparison (va,vb,vc over 1 fundamental) ===
+    inline void plot_va_vb_vc_fundamental(const std::vector<double>& va,
+                                        const std::vector<double>& vb,
+                                        const std::vector<double>& vc,
+                                        double f1,
+                                        double fs) {
+        const double Tfund = 1.0 / f1;
+        size_t Nfund = static_cast<size_t>(std::round(Tfund * fs));
+        Nfund = std::min({Nfund, va.size(), vb.size(), vc.size()});
+
+        std::vector<double> va_fund(va.begin(), va.begin() + Nfund);
+        std::vector<double> vb_fund(vb.begin(), vb.begin() + Nfund);
+        std::vector<double> vc_fund(vc.begin(), vc.begin() + Nfund);
+
+        auto t = linspace(0, Tfund, Nfund);
+        figure(true);
+        hold(true);
+        plot(t, va_fund)->display_name("va");
+        plot(t, vb_fund)->display_name("vb");
+        plot(t, vc_fund)->display_name("vc");
+        legend();
+        xlabel("Time [s]");
+        ylabel("Voltage [V]");
+        title("va, vb, vc (1 fundamental period)");
+        hold(false);
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("va_vb_vc_fundamental.png"));
+    }
+
+    inline void plot_fft_vl1_il1(const std::vector<double>& freq,
+                                const std::vector<double>& Vl1_fft,
+                                const std::vector<double>& Il1_fft) {
+        figure(true);
+        hold(true);
+
+        std::vector<double> Vl1_dB(Vl1_fft.size());
+        std::transform(Vl1_fft.begin(), Vl1_fft.end(), Vl1_dB.begin(),
+                    [](double v){ return 20.0*std::log10(std::max(v,1e-12)); });
+
+        std::vector<double> Il1_dB(Il1_fft.size());
+        std::transform(Il1_fft.begin(), Il1_fft.end(), Il1_dB.begin(),
+                    [](double v){ return 20.0*std::log10(std::max(v,1e-12)); });
+
+        semilogx(freq, Vl1_dB)->display_name("|V_L1(f)| [dB]");
+        semilogx(freq, Il1_dB)->display_name("|I_L1(f)| [dB]");
+
+        legend();
+        xlabel("Frequency [Hz]");
+        ylabel("Amplitude [dB]");
+        title("FFT of vL1 and iL1");
+        grid(true);
+
+        hold(false);
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("fft_vl1_il1.png"));
+    }
+
+    // === 6. Instantaneous power p(t) over 1 fundamental + diagnostics ===
+    inline void plot_power(const std::vector<double>& p,
+                        double f1) {
+        auto t = linspace(0, 1.0 / f1, p.size());
+        figure(true);
+        plot(t, p);
+        xlabel("Time [s]");
+        ylabel("Power [W]");
+        title("Instantaneous Power p(t)");
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("power.png"));
+
+        // --- Diagnostics ---
+        double sum = std::accumulate(p.begin(), p.end(), 0.0);
+        double p_avg = sum / static_cast<double>(p.size());
+
+        double sq_sum = std::inner_product(p.begin(), p.end(), p.begin(), 0.0);
+        double p_rms = std::sqrt(sq_sum / static_cast<double>(p.size()));
+
+        auto [min_it, max_it] = std::minmax_element(p.begin(), p.end());
+        double p_min = *min_it;
+        double p_max = *max_it;
+
+        std::cout << "[Power diagnostics] "
+                << "avg = " << p_avg << " W, "
+                << "RMS = " << p_rms << " W, "
+                << "min = " << p_min << " W, "
+                << "max = " << p_max << " W"
+                << std::endl;
+    }
+
+    // === 7. vdc(t) ripple over fundamental ===
+    inline void plot_vdc_ripple(const std::vector<double>& vdc,
+                                double f1) {
+        auto t = linspace(0, 1.0 / f1, vdc.size());
+        figure(true);
+        plot(t, vdc);
+        xlabel("Time [s]");
+        ylabel("Vdc [V]");
+        title("DC Bus Voltage with Ripple");
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("vdc_ripple.png"));
+    }
+
+    // === 8. Final FFT result (vL1 & iL1 again after ripple) ===
+    inline void plot_final_fft_vl1_il1(const std::vector<double>& freq,
+                                    const std::vector<double>& Vl1_fft,
+                                    const std::vector<double>& Il1_fft) {
+        figure(true);
+        hold(true);
+
+        // Convert magnitude → dB (20*log10), clamp small values
+        std::vector<double> Vl1_dB(Vl1_fft.size());
+        std::transform(Vl1_fft.begin(), Vl1_fft.end(), Vl1_dB.begin(),
+                    [](double v) {
+                        double mag = std::abs(v);
+                        return (mag > 1e-20) ? 20.0 * std::log10(mag) : -200.0; // dB floor
+                    });
+
+        std::vector<double> Il1_dB(Il1_fft.size());
+        std::transform(Il1_fft.begin(), Il1_fft.end(), Il1_dB.begin(),
+                    [](double v) {
+                        double mag = std::abs(v);
+                        return (mag > 1e-20) ? 20.0 * std::log10(mag) : -200.0;
+                    });
+
+        // Plot with log frequency axis
+        semilogx(freq, Vl1_dB)->display_name("|V_L1(f)| final [dB]");
+        semilogx(freq, Il1_dB)->display_name("|I_L1(f)| final [dB]");
+
+        legend();
+        xlabel("Frequency [Hz]");
+        ylabel("Amplitude [dB]");
+        title("Final FFT of vL1 and iL1");
+        grid(true);
+
+        hold(false);
+        gcf()->size(1920, 1080);   // set figure size (in pixels)
+        save(path("final_fft_vl1_il1.png"));
+    }
+} // namespace debug_plots
+#endif

--- a/src/converter_models/Topology.h
+++ b/src/converter_models/Topology.h
@@ -227,6 +227,7 @@ private:
                                     double omega,
                                     std::complex<double> Vinv);
     HarmonicsBundle compute_harmonics(const Modulation& modulation,
+                                    const InverterOperatingPoint& op_point,
                                     const ABCVoltages& Vabc,
                                     double Vdc,
                                     std::complex<double> Vfund,

--- a/tests/TestTwoLevelInverter.cpp
+++ b/tests/TestTwoLevelInverter.cpp
@@ -1,0 +1,303 @@
+#include "support/Painter.h"
+#define private public
+#define protected public
+#include "converter_models/Topology.h"
+#undef private
+#undef protected
+#include "json.hpp"
+#include <UnitTest++.h>
+#include <filesystem>
+#include <vector>
+#include <cmath>
+
+using namespace MAS;
+using namespace OpenMagnetics;
+using json = nlohmann::json;
+
+SUITE(TwoLevelInverter) {
+    auto outputFilePath = std::filesystem::path{__FILE__}.parent_path().append("..").append("output");
+
+    TEST(Test_Inverter_SPWM_3phase) {
+        std::filesystem::create_directories(outputFilePath);
+
+        json invJson;
+        invJson["dcBusVoltage"]["nominal"] = 400.0;
+        invJson["dcBusCapacitor"]["capacitance"] = 1e-3;
+        invJson["numberOfLegs"] = 3; // single-phase
+        invJson["inverterLegPowerRating"] = 1000.0;
+        invJson["lineRmsCurrent"]["nominal"] = 5.0;
+        invJson["modulation"]["switchingFrequency"] = 10000.0;
+        invJson["modulation"]["pwmType"] = "triangular";
+        invJson["modulation"]["modulationStrategy"] = "SPWM";
+        invJson["modulation"]["modulationDepth"] = 0.5;
+        json op;
+        op["fundamentalFrequency"] = 50.0;
+        op["outputPower"] = 100.0;
+        op["powerFactor"] = 1.0;
+        op["load"]["loadType"] = "grid";
+        op["load"]["gridFrequency"] = 50;
+        op["load"]["gridResistance"] = 0.0001;
+        op["load"]["gridInductance"] = 1e-7;
+        op["currentPhaseAngle"] = 0.0;
+        invJson["operatingPoints"] = json::array({op});
+        invJson["downstreamFilter"]["filterTopology"] = "L";
+        invJson["downstreamFilter"]["inductor"]["desiredInductance"]["nominal"] = 1e-3; // 1 mH
+        invJson["downstreamFilter"]["inductor"]["resistance"] = 0.01; // 10 mΩ
+
+        // Construct inverter
+        MyInverter inverter(invJson);
+
+        // Call normal workflow → this internally computes harmonics + plots if DEBUG_PLOTS
+        auto results = inverter.process_operating_points();
+
+        // Just check results exist
+        CHECK(!results.empty());
+
+        // Check that debug plots were generated
+    #ifdef DEBUG_PLOTS
+        CHECK(std::filesystem::exists("debug_plots/carrier_vs_refs.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_short.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_fundamental.png"));
+        CHECK(std::filesystem::exists("debug_plots/power.png"));
+        CHECK(std::filesystem::exists("debug_plots/vdc_ripple.png"));
+        CHECK(std::filesystem::exists("debug_plots/fft_vl1_il1.png"));
+        CHECK(std::filesystem::exists("debug_plots/final_fft_vl1_il1.png"));
+    #endif
+    }
+    TEST(Test_Inverter_SVPWM_3phase) {
+        std::filesystem::create_directories(outputFilePath);
+
+        json invJson;
+        invJson["dcBusVoltage"]["nominal"] = 400.0;
+        invJson["dcBusCapacitor"]["capacitance"] = 1e-3;
+        invJson["numberOfLegs"] = 3; // single-phase
+        invJson["inverterLegPowerRating"] = 1000.0;
+        invJson["lineRmsCurrent"]["nominal"] = 5.0;
+        invJson["modulation"]["switchingFrequency"] = 10000.0;
+        invJson["modulation"]["pwmType"] = "triangular";
+        invJson["modulation"]["modulationStrategy"] = "SVPWM";
+        invJson["modulation"]["modulationDepth"] = 0.5;
+        json op;
+        op["fundamentalFrequency"] = 50.0;
+        op["outputPower"] = 100.0;
+        op["powerFactor"] = 1.0;
+        op["load"]["loadType"] = "grid";
+        op["load"]["gridFrequency"] = 50;
+        op["load"]["gridResistance"] = 0.0001;
+        op["load"]["gridInductance"] = 1e-7;
+        op["currentPhaseAngle"] = 0.0;
+        invJson["operatingPoints"] = json::array({op});
+        invJson["downstreamFilter"]["filterTopology"] = "L";
+        invJson["downstreamFilter"]["inductor"]["desiredInductance"]["nominal"] = 1e-3; // 1 mH
+        invJson["downstreamFilter"]["inductor"]["resistance"] = 0.01; // 10 mΩ
+
+        // Construct inverter
+        MyInverter inverter(invJson);
+
+        // Call normal workflow → this internally computes harmonics + plots if DEBUG_PLOTS
+        auto results = inverter.process_operating_points();
+
+        // Just check results exist
+        CHECK(!results.empty());
+
+        // Check that debug plots were generated
+    #ifdef DEBUG_PLOTS
+        CHECK(std::filesystem::exists("debug_plots/carrier_vs_refs.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_short.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_fundamental.png"));
+        CHECK(std::filesystem::exists("debug_plots/power.png"));
+        CHECK(std::filesystem::exists("debug_plots/vdc_ripple.png"));
+        CHECK(std::filesystem::exists("debug_plots/fft_vl1_il1.png"));
+        CHECK(std::filesystem::exists("debug_plots/final_fft_vl1_il1.png"));
+    #endif
+    }
+    TEST(Test_Inverter_THIPWM_3phase) {
+        std::filesystem::create_directories(outputFilePath);
+
+        json invJson;
+        invJson["dcBusVoltage"]["nominal"] = 400.0;
+        invJson["dcBusCapacitor"]["capacitance"] = 1e-3;
+        invJson["numberOfLegs"] = 3; // single-phase
+        invJson["inverterLegPowerRating"] = 1000.0;
+        invJson["lineRmsCurrent"]["nominal"] = 5.0;
+        invJson["modulation"]["switchingFrequency"] = 10000.0;
+        invJson["modulation"]["pwmType"] = "triangular";
+        invJson["modulation"]["modulationStrategy"] = "THIPWM";
+        invJson["modulation"]["thirdHarmonicInjectionCoefficient"] = 0.166;
+        invJson["modulation"]["modulationDepth"] = 0.5;
+        json op;
+        op["fundamentalFrequency"] = 50.0;
+        op["outputPower"] = 100.0;
+        op["powerFactor"] = 1.0;
+        op["load"]["loadType"] = "grid";
+        op["load"]["gridFrequency"] = 50;
+        op["load"]["gridResistance"] = 0.0001;
+        op["load"]["gridInductance"] = 1e-7;
+        op["currentPhaseAngle"] = 0.0;
+        invJson["operatingPoints"] = json::array({op});
+        invJson["downstreamFilter"]["filterTopology"] = "L";
+        invJson["downstreamFilter"]["inductor"]["desiredInductance"]["nominal"] = 1e-3; // 1 mH
+        invJson["downstreamFilter"]["inductor"]["resistance"] = 0.01; // 10 mΩ
+
+        // Construct inverter
+        MyInverter inverter(invJson);
+
+        // Call normal workflow → this internally computes harmonics + plots if DEBUG_PLOTS
+        auto results = inverter.process_operating_points();
+
+        // Just check results exist
+        CHECK(!results.empty());
+
+        // Check that debug plots were generated
+    #ifdef DEBUG_PLOTS
+        CHECK(std::filesystem::exists("debug_plots/carrier_vs_refs.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_short.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_fundamental.png"));
+        CHECK(std::filesystem::exists("debug_plots/power.png"));
+        CHECK(std::filesystem::exists("debug_plots/vdc_ripple.png"));
+        CHECK(std::filesystem::exists("debug_plots/fft_vl1_il1.png"));
+        CHECK(std::filesystem::exists("debug_plots/final_fft_vl1_il1.png"));
+    #endif
+    }
+    TEST(Test_Inverter_SPWM_2phase) {
+        std::filesystem::create_directories(outputFilePath);
+
+        json invJson;
+        invJson["dcBusVoltage"]["nominal"] = 400.0;
+        invJson["dcBusCapacitor"]["capacitance"] = 1e-3;
+        invJson["numberOfLegs"] = 2; // single-phase
+        invJson["inverterLegPowerRating"] = 1000.0;
+        invJson["lineRmsCurrent"]["nominal"] = 5.0;
+        invJson["modulation"]["switchingFrequency"] = 10000.0;
+        invJson["modulation"]["pwmType"] = "triangular";
+        invJson["modulation"]["modulationStrategy"] = "SPWM";
+        invJson["modulation"]["modulationDepth"] = 0.5;
+        json op;
+        op["fundamentalFrequency"] = 50.0;
+        op["outputPower"] = 100.0;
+        op["powerFactor"] = 1.0;
+        op["load"]["loadType"] = "grid";
+        op["load"]["gridFrequency"] = 50;
+        op["load"]["gridResistance"] = 0.0001;
+        op["load"]["gridInductance"] = 1e-7;
+        op["currentPhaseAngle"] = 0.0;
+        invJson["operatingPoints"] = json::array({op});
+        invJson["downstreamFilter"]["filterTopology"] = "L";
+        invJson["downstreamFilter"]["inductor"]["desiredInductance"]["nominal"] = 1e-3; // 1 mH
+        invJson["downstreamFilter"]["inductor"]["resistance"] = 0.01; // 10 mΩ
+
+        // Construct inverter
+        MyInverter inverter(invJson);
+
+        // Call normal workflow → this internally computes harmonics + plots if DEBUG_PLOTS
+        auto results = inverter.process_operating_points();
+
+        // Just check results exist
+        CHECK(!results.empty());
+
+        // Check that debug plots were generated
+    #ifdef DEBUG_PLOTS
+        CHECK(std::filesystem::exists("debug_plots/carrier_vs_refs.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_short.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_fundamental.png"));
+        CHECK(std::filesystem::exists("debug_plots/power.png"));
+        CHECK(std::filesystem::exists("debug_plots/vdc_ripple.png"));
+        CHECK(std::filesystem::exists("debug_plots/fft_vl1_il1.png"));
+        CHECK(std::filesystem::exists("debug_plots/final_fft_vl1_il1.png"));
+    #endif
+    }
+    TEST(Test_Inverter_SVPWM_2phase) {
+        std::filesystem::create_directories(outputFilePath);
+
+        json invJson;
+        invJson["dcBusVoltage"]["nominal"] = 400.0;
+        invJson["dcBusCapacitor"]["capacitance"] = 1e-3;
+        invJson["numberOfLegs"] = 2; // single-phase
+        invJson["inverterLegPowerRating"] = 1000.0;
+        invJson["lineRmsCurrent"]["nominal"] = 5.0;
+        invJson["modulation"]["switchingFrequency"] = 10000.0;
+        invJson["modulation"]["pwmType"] = "triangular";
+        invJson["modulation"]["modulationStrategy"] = "SVPWM";
+        invJson["modulation"]["modulationDepth"] = 0.5;
+        json op;
+        op["fundamentalFrequency"] = 50.0;
+        op["outputPower"] = 100.0;
+        op["powerFactor"] = 1.0;
+        op["load"]["loadType"] = "grid";
+        op["load"]["gridFrequency"] = 50;
+        op["load"]["gridResistance"] = 0.0001;
+        op["load"]["gridInductance"] = 1e-7;
+        op["currentPhaseAngle"] = 0.0;
+        invJson["operatingPoints"] = json::array({op});
+        invJson["downstreamFilter"]["filterTopology"] = "L";
+        invJson["downstreamFilter"]["inductor"]["desiredInductance"]["nominal"] = 1e-3; // 1 mH
+        invJson["downstreamFilter"]["inductor"]["resistance"] = 0.01; // 10 mΩ
+
+        // Construct inverter
+        MyInverter inverter(invJson);
+
+        // Call normal workflow → this internally computes harmonics + plots if DEBUG_PLOTS
+        auto results = inverter.process_operating_points();
+
+        // Just check results exist
+        CHECK(!results.empty());
+
+        // Check that debug plots were generated
+    #ifdef DEBUG_PLOTS
+        CHECK(std::filesystem::exists("debug_plots/carrier_vs_refs.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_short.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_fundamental.png"));
+        CHECK(std::filesystem::exists("debug_plots/power.png"));
+        CHECK(std::filesystem::exists("debug_plots/vdc_ripple.png"));
+        CHECK(std::filesystem::exists("debug_plots/fft_vl1_il1.png"));
+        CHECK(std::filesystem::exists("debug_plots/final_fft_vl1_il1.png"));
+    #endif
+    }
+    TEST(Test_Inverter_THIPWM_2phase) {
+        std::filesystem::create_directories(outputFilePath);
+
+        json invJson;
+        invJson["dcBusVoltage"]["nominal"] = 400.0;
+        invJson["dcBusCapacitor"]["capacitance"] = 1e-3;
+        invJson["numberOfLegs"] = 2; // single-phase
+        invJson["inverterLegPowerRating"] = 1000.0;
+        invJson["lineRmsCurrent"]["nominal"] = 5.0;
+        invJson["modulation"]["switchingFrequency"] = 10000.0;
+        invJson["modulation"]["pwmType"] = "triangular";
+        invJson["modulation"]["modulationStrategy"] = "THIPWM";
+        invJson["modulation"]["modulationDepth"] = 0.5;
+        json op;
+        op["fundamentalFrequency"] = 50.0;
+        op["outputPower"] = 100.0;
+        op["powerFactor"] = 1.0;
+        op["load"]["loadType"] = "grid";
+        op["load"]["gridFrequency"] = 50;
+        op["load"]["gridResistance"] = 0.0001;
+        op["load"]["gridInductance"] = 1e-7;
+        op["currentPhaseAngle"] = 0.0;
+        invJson["operatingPoints"] = json::array({op});
+        invJson["downstreamFilter"]["filterTopology"] = "L";
+        invJson["downstreamFilter"]["inductor"]["desiredInductance"]["nominal"] = 1e-3; // 1 mH
+        invJson["downstreamFilter"]["inductor"]["resistance"] = 0.01; // 10 mΩ
+
+        // Construct inverter
+        MyInverter inverter(invJson);
+
+        // Call normal workflow → this internally computes harmonics + plots if DEBUG_PLOTS
+        auto results = inverter.process_operating_points();
+
+        // Just check results exist
+        CHECK(!results.empty());
+
+        // Check that debug plots were generated
+    #ifdef DEBUG_PLOTS
+        CHECK(std::filesystem::exists("debug_plots/carrier_vs_refs.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_short.png"));
+        CHECK(std::filesystem::exists("debug_plots/va_vb_vc_fundamental.png"));
+        CHECK(std::filesystem::exists("debug_plots/power.png"));
+        CHECK(std::filesystem::exists("debug_plots/vdc_ripple.png"));
+        CHECK(std::filesystem::exists("debug_plots/fft_vl1_il1.png"));
+        CHECK(std::filesystem::exists("debug_plots/final_fft_vl1_il1.png"));
+    #endif
+    }
+}


### PR DESCRIPTION
So far the proposed wizard would permit designing inductors for L, LC, and LCL filters. 
The feature proposal is linked with the topology extension for MAS proposed under : 
https://github.com/OpenMagnetics/MAS/pull/18

![inverterMKF](https://github.com/user-attachments/assets/249f2cab-2411-4aa9-b2c4-1072c81ec609)
The MAS twoLevelInverter topology permits to defines all parameters linked with the system above. 

In the MKF, I propose a draft solver to find the design constraints on the magnetic of the filter in order to be able to size them using OpenMagnetics. 

The current proposal first determine the inverter reference, using different state of the art modulation technics such as SPWM, SVPWM, or THIPWM. 

Then PWM carrier are computed (either Sawtooth or Triangular are supported).

Then we compute the comparison of the reference and the carrier, and we deal with dead-time and rise-time of the switches. 

This gives the voltage waveform for each switching node of the inverter. 

Then, depending on the filter topology, we compute the voltage drop across the first inductor, and the current flowing in the first inductor. 

From that, we derive the harmonics using a simple DFT. 

The harmonics are fed to OM to compute magnetic losses, encompassing both fundamental frequencies and switching frequencies. 


**Self-criticism and TODOs:** 

- [x] not taking DC Bus ripple in consideration so far which has huge impact on low freq harmonics.
- [x] could be improved to be more explicit if inverter is a 3phase one, or a single phase (not the same impact from DC Ripple)
- [ ] Not yet possible to derive constraints for the second inductor.
- [ ] Not reusing already implemented FFT features
- [x] Figure out linker error
- [ ] Not tested 
